### PR TITLE
Generic trouble ticket model with code generator compatibility

### DIFF
--- a/common/schemas/Attachment.openapi.yaml
+++ b/common/schemas/Attachment.openapi.yaml
@@ -102,5 +102,3 @@ components:
                 - REJECTED
       discriminator:
         propertyName: "@baseType"
-      required:
-        - "@baseType"

--- a/common/schemas/Attachment.openapi.yaml
+++ b/common/schemas/Attachment.openapi.yaml
@@ -87,9 +87,6 @@ components:
             relatedEntity:
               description: The entities related to the attachment. This property has to be overriden in the derived class.
               type: object
-            "@baseType":
-              type: string
-              example: "TroubleTicketAttachment"
             "@type":
               type: string
               example: "TroubleTicketAttachment"

--- a/common/schemas/Attachment.openapi.yaml
+++ b/common/schemas/Attachment.openapi.yaml
@@ -9,7 +9,7 @@ info:
 
 components:
   schemas:
-    Attachment:
+    TMFAttachment:
       description: An attachment is a file that is attached to an entity.
       externalDocs:
         url: https://datamodel.tmforum.org/en/latest/Common/EntityAttachment
@@ -80,3 +80,30 @@ components:
               type: string
               readOnly: true
               example: 8cf1bc0fca7f4158b8eb807be15fd7fd21bfe52d956ce3ede1511671c97dad61
+    TroubleTicketAttachment:
+      allOf:
+        - $ref: "#/components/schemas/TMFAttachment"
+        - properties:
+            relatedEntity:
+              description: The entities related to the attachment. This property has to be overriden in the derived class.
+              type: object
+            "@baseType":
+              type: string
+              example: "TroubleTicketAttachment"
+            "@type":
+              type: string
+              example: "TroubleTicketAttachment"
+            mimeType:
+              description: The mime type of the attachment. This property has to be overriden in the derived class.
+              type: object
+            status:
+              description: The status of the attachment.
+              type: string
+              enum:
+                - PENDING
+                - VALIDATED
+                - REJECTED
+      discriminator:
+        propertyName: "@baseType"
+      required:
+        - "@baseType"

--- a/common/schemas/CloudEvent.openapi.yaml
+++ b/common/schemas/CloudEvent.openapi.yaml
@@ -79,21 +79,29 @@ components:
           description: Describes the subject of the event in the context of the event producer (identified by source).
           example: mynewfile.jpg
           minLength: 1
-        # data:
-        #   oneOf:
-        #     - type: string
-        #     - type: object
-        #     - type: array
-        #     - type: number
-        #     - type: boolean
-        #     - type: integer
-        #   nullable: true
-        #   description: The event payload.
-        #   example: '{"hello": "world"}'
-        # data_base64:
-        #   type: string
-        #   nullable: true
-        #   description: Base64 encoded event payload.
-        #     Must adhere to [RFC 4648](https://datatracker.ietf.org/doc/html/rfc4648).
-        #   example: eyJoZWxsbyI6ICJ3b3JsZCJ9
-        #   minLength: 1
+    TroubleTicketEvent:
+      allOf:
+        - $ref: "#/components/schemas/CloudEvent"
+        - properties:
+            subject:
+              description: Identifiant unique de l'anomalie.
+              format: uuid
+              type: string
+            datacontenttype:
+              default: application/json
+              example: application/json
+              type: string
+      discriminator:
+        propertyName: "@baseType"
+      required:
+        - subject
+        - time
+      example:
+        datacontenttype: application/json
+        subject: 046b6c7f-0b8a-43b9-b35d-6489e6daee91
+        specversion: "1.0"
+        source: https://github.com/cloudevents
+        id: A234-1234-1234
+        time: 2018-04-05T17:31:00Z
+        type: type
+        dataschema: http://cloudevents.io/schema.json

--- a/common/schemas/CloudEvent.openapi.yaml
+++ b/common/schemas/CloudEvent.openapi.yaml
@@ -84,7 +84,7 @@ components:
         - $ref: "#/components/schemas/CloudEvent"
         - properties:
             subject:
-              description: Identifiant unique de l'anomalie.
+              description: Identifiant unique du troubleticket.
               format: uuid
               type: string
             datacontenttype:

--- a/common/schemas/Note.openapi.yaml
+++ b/common/schemas/Note.openapi.yaml
@@ -9,7 +9,7 @@ info:
 
 components:
   schemas:
-    Note:
+    TMFNote:
       description: A note is a text that can be attached to an entity.
       externalDocs:
         url: https://datamodel.tmforum.org/en/latest/Common/Note
@@ -52,3 +52,16 @@ components:
               items:
                 $ref: "./RelatedEntity.openapi.yaml#/components/schemas/RelatedEntity"
               readOnly: true
+    TroubleTicketNote:
+      allOf:
+        - $ref: "#/components/schemas/TMFNote"
+        - properties:
+            relatedEntity:
+              description: The entities related to the attachment. This property has to be overriden in the derived class.
+              type: object
+      discriminator:
+        propertyName: "@baseType"
+        mapping:
+          - AnomalieAdresseNote:
+      required:
+        - "@baseType"

--- a/common/schemas/Note.openapi.yaml
+++ b/common/schemas/Note.openapi.yaml
@@ -56,12 +56,18 @@ components:
       allOf:
         - $ref: "#/components/schemas/TMFNote"
         - properties:
+            "@type":
+              type: string
+              default: "TroubleTicketNote"
+              example: "TroubleTicketNote"
+            "@baseType":
+              type: string
+              default: "TroubleTicketNote"
+              example: "TroubleTicketNote"
             relatedEntity:
               description: The entities related to the attachment. This property has to be overriden in the derived class.
               type: object
       discriminator:
         propertyName: "@baseType"
-        mapping:
-          - AnomalieAdresseNote:
       required:
         - "@baseType"

--- a/common/schemas/TroubleTicket.openapi.yaml
+++ b/common/schemas/TroubleTicket.openapi.yaml
@@ -135,7 +135,9 @@ components:
       discriminator:
         propertyName: "@baseType"
         mapping:
-          AnomalieAdresse: https://raw.githubusercontent.com/christophelach/defecto-interop-anomalieAdresse/refs/heads/generic-troubleTicket-model-for-codeGen-compatibility/openapi.yaml#/components/schemas/TroubleTicketAnomalieAdresse
+          AnomalieAdresse: "#/components/schemas/AnomalieAdresse"
       required:
         - "@baseType"
         - "@type"
+    AnomalieAdresse:
+      $ref: https://raw.githubusercontent.com/christophelach/defecto-interop-anomalieAdresse/refs/heads/generic-troubleTicket-model-for-codeGen-compatibility/openapi.yaml#/components/schemas/TroubleTicketAnomalieAdresse

--- a/common/schemas/TroubleTicket.openapi.yaml
+++ b/common/schemas/TroubleTicket.openapi.yaml
@@ -134,6 +134,8 @@ components:
               type: object
       discriminator:
         propertyName: "@baseType"
+        mapping:
+          AnomalieTroubleTicket: "#/components/schemas/TroubleTicketAnomalieAdresse"
       required:
         - "@baseType"
         - "@type"

--- a/common/schemas/TroubleTicket.openapi.yaml
+++ b/common/schemas/TroubleTicket.openapi.yaml
@@ -135,7 +135,7 @@ components:
       discriminator:
         propertyName: "@baseType"
         mapping:
-          AnomalieAdresse: "https://raw.githubusercontent.com/christophelach/defecto-interop-anomalieAdresse/generic-troubleTicket-model-for-codeGen-compatibility/openapi.yaml#/components/schemas/TroubleTicketAnomalieAdresse"
+          troubleticket.anomalieadresse: "https://raw.githubusercontent.com/christophelach/defecto-interop-anomalieAdresse/generic-troubleTicket-model-for-codeGen-compatibility/openapi.yaml#/components/schemas/TroubleTicketAnomalieAdresse"
       required:
         - "@baseType"
         - "@type"

--- a/common/schemas/TroubleTicket.openapi.yaml
+++ b/common/schemas/TroubleTicket.openapi.yaml
@@ -135,8 +135,7 @@ components:
       discriminator:
         propertyName: "@baseType"
         mapping:
-          AnomalieAdresse:
-            $ref: "https://raw.githubusercontent.com/christophelach/defecto-interop-anomalieAdresse/generic-troubleTicket-model-for-codeGen-compatibility/openapi.yaml#/components/schemas/AnomalieAdresse"
+          AnomalieAdresse: "https://raw.githubusercontent.com/christophelach/defecto-interop-anomalieAdresse/generic-troubleTicket-model-for-codeGen-compatibility/openapi.yaml#/components/schemas/TroubleTicketAnomalieAdresse"
       required:
         - "@baseType"
         - "@type"

--- a/common/schemas/TroubleTicket.openapi.yaml
+++ b/common/schemas/TroubleTicket.openapi.yaml
@@ -140,3 +140,5 @@ components:
       required:
         - "@baseType"
         - "@type"
+        - code_oc
+        - code_oi

--- a/common/schemas/TroubleTicket.openapi.yaml
+++ b/common/schemas/TroubleTicket.openapi.yaml
@@ -135,7 +135,7 @@ components:
       discriminator:
         propertyName: "@baseType"
         mapping:
-          AnomalieAdresse: "https://raw.githubusercontent.com/christophelach/defecto-interop-anomalieAdresse/generic-troubleTicket-model-for-codeGen-compatibility/openapi.yaml#/components/schemas/AnomalieAdresse"
+          AnomalieAdresse: "https://raw.githubusercontent.com/christophelach/defecto-interop-anomalieAdresse/generic-troubleTicket-model-for-codeGen-compatibility/openapi.yaml#/components/schemas/TroubleTicketAnomalieAdresse"
       required:
         - "@baseType"
         - "@type"

--- a/common/schemas/TroubleTicket.openapi.yaml
+++ b/common/schemas/TroubleTicket.openapi.yaml
@@ -134,8 +134,6 @@ components:
               type: object
       discriminator:
         propertyName: "@baseType"
-        mapping:
-          AnomalieAdresse: "https://raw.githubusercontent.com/christophelach/defecto-interop-anomalieAdresse/generic-troubleTicket-model-for-codeGen-compatibility/openapi.yaml#/components/schemas/TroubleTicketAnomalieAdresse"
       required:
         - "@baseType"
         - "@type"

--- a/common/schemas/TroubleTicket.openapi.yaml
+++ b/common/schemas/TroubleTicket.openapi.yaml
@@ -110,6 +110,9 @@ components:
             relatedEntity:
               description: The related party(ies) that are associated to the ticket. This property has to be overriden in the derived classes as an array or specific entity.
               type: object
+            relatedParty:
+              description: The related party(ies) that are associated to the ticket. This property has to be overriden in the derived classes as an array or specific entity.
+              type: object
             priority:
               description: |
                 The priority of the trouble ticket and how quickly the issue should be resolved.

--- a/common/schemas/TroubleTicket.openapi.yaml
+++ b/common/schemas/TroubleTicket.openapi.yaml
@@ -135,7 +135,7 @@ components:
       discriminator:
         propertyName: "@baseType"
         mapping:
-          troubleticket.anomalieadresse: "https://raw.githubusercontent.com/christophelach/defecto-interop-anomalieAdresse/generic-troubleTicket-model-for-codeGen-compatibility/openapi.yaml#/components/schemas/TroubleTicketAnomalieAdresse"
+          AnomalieAdresse: "https://raw.githubusercontent.com/christophelach/defecto-interop-anomalieAdresse/generic-troubleTicket-model-for-codeGen-compatibility/openapi.yaml#/components/schemas/AnomalieAdresse"
       required:
         - "@baseType"
         - "@type"

--- a/common/schemas/TroubleTicket.openapi.yaml
+++ b/common/schemas/TroubleTicket.openapi.yaml
@@ -134,6 +134,8 @@ components:
               type: object
       discriminator:
         propertyName: "@baseType"
+        mapping:
+          AnomalieAdresse: "https://raw.githubusercontent.com/christophelach/defecto-interop-anomalieAdresse/generic-troubleTicket-model-for-codeGen-compatibility/openapi.yaml#/components/schemas/TroubleTicketAnomalieAdresse"
       required:
         - "@baseType"
         - "@type"

--- a/common/schemas/TroubleTicket.openapi.yaml
+++ b/common/schemas/TroubleTicket.openapi.yaml
@@ -134,8 +134,6 @@ components:
               type: object
       discriminator:
         propertyName: "@baseType"
-        mapping:
-          AnomalieAdresse: "#/components/schemas/TroubleTicketAnomalieAdresse"
       required:
         - "@baseType"
         - "@type"

--- a/common/schemas/TroubleTicket.openapi.yaml
+++ b/common/schemas/TroubleTicket.openapi.yaml
@@ -135,7 +135,7 @@ components:
       discriminator:
         propertyName: "@baseType"
         mapping:
-          AnomalieTroubleTicket: "#/components/schemas/TroubleTicketAnomalieAdresse"
+          AnomalieTroubleTicket: TroubleTicketAnomalieAdresse
       required:
         - "@baseType"
         - "@type"

--- a/common/schemas/TroubleTicket.openapi.yaml
+++ b/common/schemas/TroubleTicket.openapi.yaml
@@ -135,7 +135,7 @@ components:
       discriminator:
         propertyName: "@baseType"
         mapping:
-          AnomalieTroubleTicket: https://raw.githubusercontent.com/christophelach/defecto-interop-anomalieAdresse/refs/heads/generic-troubleTicket-model-for-codeGen-compatibility/openapi.yaml/#components/schemas/roubleTicketAnomalieAdresse
+          AnomalieTroubleTicket: https://raw.githubusercontent.com/christophelach/defecto-interop-anomalieAdresse/refs/heads/generic-troubleTicket-model-for-codeGen-compatibility/openapi.yaml/#components/schemas/TroubleTicketAnomalieAdresse
       required:
         - "@baseType"
         - "@type"

--- a/common/schemas/TroubleTicket.openapi.yaml
+++ b/common/schemas/TroubleTicket.openapi.yaml
@@ -135,7 +135,7 @@ components:
       discriminator:
         propertyName: "@baseType"
         mapping:
-          AnomalieTroubleTicket: https://raw.githubusercontent.com/christophelach/defecto-interop-anomalieAdresse/refs/heads/generic-troubleTicket-model-for-codeGen-compatibility/openapi.yaml/#components/schemas/TroubleTicketAnomalieAdresse
+          AnomalieAdresse: https://raw.githubusercontent.com/christophelach/defecto-interop-anomalieAdresse/refs/heads/generic-troubleTicket-model-for-codeGen-compatibility/openapi.yaml#/components/schemas/TroubleTicketAnomalieAdresse
       required:
         - "@baseType"
         - "@type"

--- a/common/schemas/TroubleTicket.openapi.yaml
+++ b/common/schemas/TroubleTicket.openapi.yaml
@@ -135,7 +135,7 @@ components:
       discriminator:
         propertyName: "@baseType"
         mapping:
-          AnomalieTroubleTicket: TroubleTicketAnomalieAdresse
+          AnomalieTroubleTicket: https://raw.githubusercontent.com/christophelach/defecto-interop-anomalieAdresse/refs/heads/generic-troubleTicket-model-for-codeGen-compatibility/openapi.yaml/#components/schemas/roubleTicketAnomalieAdresse
       required:
         - "@baseType"
         - "@type"

--- a/common/schemas/TroubleTicket.openapi.yaml
+++ b/common/schemas/TroubleTicket.openapi.yaml
@@ -9,7 +9,7 @@ info:
 
 components:
   schemas:
-    TroubleTicket:
+    TMFTroubleTicket:
       description: A trouble ticket is a record of an issue
         that is created, tracked, and managed
         by a trouble ticket management system
@@ -94,3 +94,48 @@ components:
                 e.g. incident, complain, request, etc.
               type: string
               nullable: true
+    TroubleTicket:
+      allOf:
+        - $ref: "#/components/schemas/TMFTroubleTicket"
+        - properties:
+            code_oi:
+              description: Code OI de l'ARCOM
+              $ref: https://raw.githubusercontent.com/before-interop/common/v1/common/schemas/Interop.openapi.yaml#/components/schemas/CodeOperateurArcep
+            code_oc:
+              description: Code OC de l'ARCOM
+              $ref: https://raw.githubusercontent.com/before-interop/common/v1/common/schemas/Interop.openapi.yaml#/components/schemas/CodeOperateurArcep
+            status:
+              description: The condition of an troubleticket, identified through a code. This property has to be overriden in the derived classes as string or enum
+              type: object
+            relatedEntity:
+              description: The related party(ies) that are associated to the ticket. This property has to be overriden in the derived classes as an array or specific entity.
+              type: object
+            priority:
+              description: |
+                The priority of the trouble ticket and how quickly the issue should be resolved.
+                Example: Critical, High, Medium, Low.
+                The value is set by the ticket management system considering the severity, ticket type etc...
+                This property has to be overriden in the derived classes as string or enum
+              type: object
+            severity:
+              description: |
+                The severity of the issue.
+                Indicate the implication of the issue on the expected functionality
+                e.g. of a system, application, service etc..
+
+                Severity values can be for example : Critical, Major, Minor
+                This property has to be overriden in the derived classes as string or enum
+              type: object
+            ticketType:
+              description: |
+                The type of the trouble ticket. e.g. incident, complain, request,\
+                \ etc.
+                This property has to be overriden in the derived classes as string or enum
+              type: object
+      discriminator:
+        propertyName: "@baseType"
+        mapping:
+          AnomalieAdresse: "#/components/schemas/TroubleTicketAnomalie"
+      required:
+        - "@baseType"
+        - "@type"

--- a/common/schemas/TroubleTicket.openapi.yaml
+++ b/common/schemas/TroubleTicket.openapi.yaml
@@ -135,7 +135,7 @@ components:
       discriminator:
         propertyName: "@baseType"
         mapping:
-          AnomalieAdresse: "https://raw.githubusercontent.com/christophelach/defecto-interop-anomalieAdresse/generic-troubleTicket-model-for-codeGen-compatibility/openapi.yaml#/components/schemas/TroubleTicketAnomalie"
+          AnomalieAdresse: "https://raw.githubusercontent.com/christophelach/defecto-interop-anomalieAdresse/generic-troubleTicket-model-for-codeGen-compatibility/openapi.yaml#/components/schemas/TroubleTicketAnomalieAdresse"
       required:
         - "@baseType"
         - "@type"

--- a/common/schemas/TroubleTicket.openapi.yaml
+++ b/common/schemas/TroubleTicket.openapi.yaml
@@ -135,9 +135,7 @@ components:
       discriminator:
         propertyName: "@baseType"
         mapping:
-          AnomalieAdresse: "#/components/schemas/AnomalieAdresse"
+          AnomalieAdresse: "#/components/schemas/TroubleTicketAnomalieAdresse"
       required:
         - "@baseType"
         - "@type"
-    AnomalieAdresse:
-      $ref: https://raw.githubusercontent.com/christophelach/defecto-interop-anomalieAdresse/refs/heads/generic-troubleTicket-model-for-codeGen-compatibility/openapi.yaml#/components/schemas/TroubleTicketAnomalieAdresse

--- a/common/schemas/TroubleTicket.openapi.yaml
+++ b/common/schemas/TroubleTicket.openapi.yaml
@@ -135,7 +135,7 @@ components:
       discriminator:
         propertyName: "@baseType"
         mapping:
-          AnomalieAdresse: "#/components/schemas/TroubleTicketAnomalie"
+          AnomalieAdresse: "https://raw.githubusercontent.com/christophelach/defecto-interop-anomalieAdresse/generic-troubleTicket-model-for-codeGen-compatibility/openapi.yaml#/components/schemas/TroubleTicketAnomalie"
       required:
         - "@baseType"
         - "@type"

--- a/common/schemas/TroubleTicket.openapi.yaml
+++ b/common/schemas/TroubleTicket.openapi.yaml
@@ -134,6 +134,9 @@ components:
               type: object
       discriminator:
         propertyName: "@baseType"
+        mapping:
+          AnomalieAdresse:
+            $ref: "https://raw.githubusercontent.com/christophelach/defecto-interop-anomalieAdresse/generic-troubleTicket-model-for-codeGen-compatibility/openapi.yaml#/components/schemas/AnomalieAdresse"
       required:
         - "@baseType"
         - "@type"


### PR DESCRIPTION
Changes to make the trouble ticket a generic object that can be really reused when generating code with automated code generators.
Some changes can be still done (eg, fixing the base type as enum for the troubleticket)
Fix #50 